### PR TITLE
Add option to specify a specific StorageClass for PVCs

### DIFF
--- a/charts/jupyterlab/templates/pvc.yaml
+++ b/charts/jupyterlab/templates/pvc.yaml
@@ -8,6 +8,9 @@ metadata:
 spec:
   accessModes:
     - "ReadWriteMany"
+  {{- if .Values.storage.storageClass }}
+  storageClassName: "{{ .Values.storage.storageClass }}"
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.storage.size }}

--- a/charts/jupyterlab/values.schema.json
+++ b/charts/jupyterlab/values.schema.json
@@ -172,6 +172,11 @@
                     "title": "Mount path of the persistent storage",
                     "description": "mount path of the persistent storage, usually in the home folder"
                 },
+                "storageClass": {
+                    "type": "string",
+                    "title": "Storage class used for persistent volumes",
+                    "description": "The storage class to be used for persistent volumes, let empty to use the cluster default"
+                },
                 "workingDir": {
                     "type": "string",
                     "title": "Folder used as working directory",

--- a/charts/jupyterlab/values.yaml
+++ b/charts/jupyterlab/values.yaml
@@ -28,6 +28,7 @@ storage:
   enabled: true
   size: 5Gi
   mountPath: /home/jovyan/work/persistent
+  storageClass: ""
   # Let workspace empty to use the mountPath as workspace
   workingDir: /home/jovyan/work
   # Mount the distributed shared memory


### PR DESCRIPTION
The current chart only permits the use of the cluster's default StorageClass when creating Persistent Volume Claims. Given some storage class types do not support the ReadWriteMany access requirement, it is helpful to be able to optionally override the StorageClass type to be used. 