### PR TITLE
Adding a new volume for Shiny server and fixing Ingress API Version related issues.

### DIFF
--- a/charts/rstudio/README.md
+++ b/charts/rstudio/README.md
@@ -37,7 +37,7 @@ helm install rstudio dsri/rstudio \
   --set service.openshiftRoute.enabled=true \
   --set image.repository=ghcr.io/maastrichtu-ids/rstudio \
   --set image.tag=latest \
-  --set storage.mountPath=/home/rstudio \
+  --set storage.rstudio.mountPath=/home/rstudio \
   --set password=changeme
 ```
 
@@ -98,8 +98,12 @@ The following table lists the configurable parameters of the rstudio chart and t
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `false` |  |
 | serviceAccount.name | string | `"anyuid"` |  |
-| storage.enabled | bool | `true` |  |
-| storage.mountPath | string | `"/home/rstudio"` |  |
-| storage.size | string | `"5Gi"` |  |
+| storage.rstudio.enabled | bool | `true` |  |
+| storage.rstudio.mountPath | string | `"/home/rstudio"` |  |
+| storage.rstudio.size | string | `"5Gi"` |  |
+| storage.rstudio.enableDshm | bool | `true` |  |
+| storage.shiny.enabled | bool | `true` |  |
+| storage.shiny.mountPath | string | `"/srv/shiny-server"` |  |
+| storage.shiny.size | string | `"5Gi"` |  |
 | tolerations | list | `[]` |  |
 | username | string | `"rstudio"` |  |

--- a/charts/rstudio/templates/deployment.yaml
+++ b/charts/rstudio/templates/deployment.yaml
@@ -89,9 +89,13 @@ spec:
             - name: dshm
               mountPath: /dev/shm
             {{- end }}
-            {{- if .Values.storage.enabled }}
-            - name: data
-              mountPath: {{ .Values.storage.mountPath }}
+            {{- if .Values.storage.rstudio.enabled }}
+            - name: rstudio-data
+              mountPath: {{ .Values.storage.rstudio.mountPath }}
+            {{- end }}
+            {{- if .Values.storage.shiny.enabled }}
+            - name: shiny-data
+              mountPath: {{ .Values.storage.shiny.mountPath }}
             {{- end }}
       volumes:
         {{- if .Values.storage.enableDshm }}
@@ -99,10 +103,15 @@ spec:
           emptyDir:
             medium: Memory
         {{- end }}
-        {{- if .Values.storage.enabled }}
-        - name: data
+        {{- if .Values.storage.rstudio.enabled }}
+        - name: rstudio-data
           persistentVolumeClaim:
             claimName: {{ include "rstudio.fullname" . }}
+        {{- end }}
+        {{- if .Values.storage.shiny.enabled }}
+        - name: shiny-data
+          persistentVolumeClaim:
+            claimName: {{ include "rstudio.fullname" . }}-shiny
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/rstudio/templates/ingress.yaml
+++ b/charts/rstudio/templates/ingress.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.service.ingress.enabled -}}
 {{- $fullName := include "rstudio.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -33,9 +29,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
           {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/rstudio/templates/pvc.yaml
+++ b/charts/rstudio/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.storage.enabled }}
+{{- if .Values.storage.rstudio.enabled }}
 kind: "PersistentVolumeClaim"
 apiVersion: "v1"
 metadata:
@@ -10,5 +10,20 @@ spec:
     - "ReadWriteMany"
   resources:
     requests:
-      storage: {{ .Values.storage.size }}
+      storage: {{ .Values.storage.rstudio.size }}
+{{- end }}
+---
+{{- if .Values.storage.shiny.enabled }}
+kind: "PersistentVolumeClaim"
+apiVersion: "v1"
+metadata:
+  name: {{ include "rstudio.fullname" . }}-shiny
+  labels:
+    {{- include "rstudio.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - "ReadWriteMany"
+  resources:
+    requests:
+      storage: {{ .Values.storage.shiny.size }}
 {{- end }}

--- a/charts/rstudio/values.schema.json
+++ b/charts/rstudio/values.schema.json
@@ -140,28 +140,67 @@
             "title": "Persistent storage",
             "description": "Configure the persistent volume to store your data.",
             "required": [
-                "size",
-                "mountPath"
+                "rstudio",
+                "shiny"
             ],
             "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "title": "Enabled"
+                "rstudio": {
+                    "type": "object",
+                    "title": "Persistent storage",
+                    "description": "Configure the persistent volume to store your rstudio data.",
+                    "required": [
+                        "enabled",
+                        "size",
+                        "mountPath",
+                        "enableDshm"
+                    ],
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "title": "Enabled"
+                        },
+                        "size": {
+                            "type": "string",
+                            "title": "Size of the persistent storage",
+                            "description": "Size of the persistent storage created"
+                        },
+                        "mountPath": {
+                            "type": "string",
+                            "title": "Mount path of the persistent storage",
+                            "description": "mount path of the persistent storage, usually in the home folder"
+                        },
+                        "enableDshm": {
+                            "type": "boolean",
+                            "title": "Mount the distributed shared memory",
+                            "description": "Can increase performance of some operation. Mount /dev/shm on memory"
+                        }
+                    }
                 },
-                "size": {
-                    "type": "string",
-                    "title": "Size of the persistent storage",
-                    "description": "Size of the persistent storage created"
-                },
-                "mountPath": {
-                    "type": "string",
-                    "title": "Mount path of the persistent storage",
-                    "description": "mount path of the persistent storage, usually in the home folder"
-                },
-                "enableDshm": {
-                    "type": "boolean",
-                    "title": "Mount the distributed shared memory",
-                    "description": "Can increase performance of some operation. Mount /dev/shm on memory"
+                "shiny": {
+                    "type": "object",
+                    "title": "Persistent storage",
+                    "description": "Configure the persistent volume to store your shiny data.",
+                    "required": [
+                        "enabled",
+                        "size",
+                        "mountPath"
+                    ],
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "title": "Enabled"
+                        },
+                        "size": {
+                            "type": "string",
+                            "title": "Size of the persistent storage",
+                            "description": "Size of the persistent storage created"
+                        },
+                        "mountPath": {
+                            "type": "string",
+                            "title": "Mount path of the persistent storage",
+                            "description": "mount path of the persistent storage, usually in the home folder"
+                        }
+                    }
                 }
             },
             "additionalProperties": true

--- a/charts/rstudio/values.yaml
+++ b/charts/rstudio/values.yaml
@@ -16,11 +16,16 @@ image:
   # or IfNotPresent
 
 storage:
-  enabled: true
-  size: 5Gi
-  mountPath: /home/rstudio
-  # Mount the distributed shared memory
-  enableDshm: true
+  rstudio:
+    enabled: true
+    size: 5Gi
+    mountPath: /home/rstudio
+    # Mount the distributed shared memory
+    enableDshm: true
+  shiny:
+    enabled: true
+    size: 5Gi
+    mountPath: /srv/shiny-server
 
 serviceAccount:
   sudoEnabled: true


### PR DESCRIPTION
The current helm chart only permits using a volume to mount rstudio server data, but not shiny server data. In the existing pull request, I've added an additional PVC and a new volume/volumeMount for the Shiny server data.
Also, the current API version of Ingres needs to be fixed. I've updated it to networking.k8s.io/v1 and changed the ingress content accordingly.